### PR TITLE
fix: add commented Authorization header to generated script

### DIFF
--- a/src/main/java/com/k6/weaver/generator/K6ScriptGenerator.java
+++ b/src/main/java/com/k6/weaver/generator/K6ScriptGenerator.java
@@ -56,9 +56,11 @@ public class K6ScriptGenerator {
             k6Script.append("   let " + payloadName + " = /* write body here! */ null;\n");
         }
 
+        k6Script.append("const token = 'your_token_here';\n");
         k6Script.append("   let params = {\n" +
                 "           headers: {\n" +
                 "               'Content-Type': 'application/json',\n" +
+                "               // 'Authorization': `Bearer ${token}`,\n" +
                 "           },\n" +
                 "       };\n");
         k6Script.append("let res;\n");


### PR DESCRIPTION
## #️⃣연관된 이슈

#14

## 📝작업 내용
웹 서비스 부하 테스트를 위해 k6Weaver를 사용할 때, 스크립트 결과에서 인증 토큰 관련 Authorization 헤더가 누락되어 
직접 추가해야 하는 불편함이 있었습니다. 이를 해결하기 위해, k6ScriptGenerator 클래스 내에 Authorization 헤더를 추가하고, 
해당 라인을 주석 처리된 상태로 출력하도록 수정했습니다.

### 기존 K6Weaver Script

![image](https://github.com/user-attachments/assets/4c718dba-f913-4c15-b5ec-9843a5e7bfab)

### 수정된 K6Weaver Script

<img width="965" alt="스크린샷 2025-04-13 오후 7 45 00" src="https://github.com/user-attachments/assets/577fc0b5-b7cc-4008-ad44-ca98804bac7a" />

## 💬리뷰 요구사항(선택)

편의성을 위해 토큰 저장용 변수 `token`을 만들었습니다.

```javascript
const token = 'your_token_here';
```


